### PR TITLE
Removed entropy checker on startup.

### DIFF
--- a/rfc3161.go
+++ b/rfc3161.go
@@ -5,8 +5,6 @@ import (
 	"encoding/asn1"
 	"errors"
 	"mime"
-
-	"github.com/cryptoballot/entropychecker"
 )
 
 // Misc Errors
@@ -89,15 +87,7 @@ func setMimeTypes() error {
 }
 
 func init() {
-	// Make sure we have sufficient entropy and fail to start if there isn't
-	// This only works on Linux.
-	err := entropychecker.WaitForEntropy()
-	if err != nil && err != entropychecker.ErrUnsupportedOS {
-		panic(err)
-	}
-
-	err = setMimeTypes()
-	if err != nil {
+	if err := setMimeTypes(); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
Removed the entropy check from `init()` because it can slow down a program's startup time.  

There's also no guarantee that the required amount of entropy will be available due to this check *at the time of requesting a timestamp* anyhow. It should be up to the package user to ensure sufficient entropy is available, at the time it is needed.