### PR TITLE
Export TimeStampToken OID.

### DIFF
--- a/rfc3161.go
+++ b/rfc3161.go
@@ -34,6 +34,9 @@ var (
 
 	// RFC-3161: iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) pkcs-9(9) smime(16) ct(1) 4
 	OidContentTypeTSTInfo = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 16, 1, 4}
+
+	// RFC-3161: iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) pkcs-9(9) smime(16) aa(2) 14
+	OidContentTypeTimeStampToken = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 16, 2, 14}
 )
 
 // Supported Extensions.


### PR DESCRIPTION
This OID is useful when adding a secure timestamp to a CMS signature; since it is defined in RFC3161 (Appendix A), it makes sense to define it here.